### PR TITLE
feat: Update iso-locales.json to add Balinese

### DIFF
--- a/packages/plugins/i18n/server/src/constants/iso-locales.json
+++ b/packages/plugins/i18n/server/src/constants/iso-locales.json
@@ -188,6 +188,10 @@
     "name": "Bahamas Creole English"
   },
   {
+    "code": "ban",
+    "name": "Balinese"
+  },
+  {
     "code": "bm",
     "name": "Bambara (bm)"
   },


### PR DESCRIPTION
Added locale for Balinese (Basa Bali) language
Reference: https://en.wikipedia.org/wiki/Balinese_language

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the tests
- Create or update the documentation at https://github.com/strapi/documentation
- Refer to the issue you are closing in the PR description: Fix #issue
- Specify if the PR is ready to be merged or work in progress (by opening a draft PR)

Please ensure you read the Contributing Guide: https://github.com/strapi/strapi/blob/main/CONTRIBUTING.md
-->

### What does it do?

Adds a new locale entry for Balinese with the code ban in the correct alphabetical position.

### Why is it needed?

More internationalization is always needed for a global product

### How to test it?

Pull this branch.

Navigate to the packages/core/admin/iso-locales.json file and confirm the new entry exists.

Run yarn build --clean to rebuild the admin panel.

Start Strapi with yarn develop.

Go to Settings → Internationalization → Locales in the admin panel.

Click Add new locale and verify that Balinese (ban) appears in the list.
